### PR TITLE
Increased coin rewards for some activities

### DIFF
--- a/Cogs/games.py
+++ b/Cogs/games.py
@@ -44,7 +44,8 @@ class Games(commands.Cog):
                         return
 
         if random.random() < 0.1 and database.is_botban(message.author.id) is None:
-            database.add_money(message.author.id, message.guild.id, 1, 0)
+            coins_to_add = 3
+            database.add_money(message.author.id, message.guild.id, coins_to_add, 0)
 
         try:
             data = database.get_config_raw('counting', message.guild.id).split('_')  # [number, channel, member, message, count_length]

--- a/Cogs/games.py
+++ b/Cogs/games.py
@@ -35,8 +35,9 @@ class Games(commands.Cog):
                             user_id = int(embed.to_dict()['description'][2:20].replace('>', ''))
                             if database.is_botban(user_id) is not None:
                                 return
-                            database.add_money(user_id, message.guild.id, 50, 0)
-                            embed = discord.Embed(description=f"<@{user_id}> received 50 <a:pinkcoin:968277243946233906> for Bumping the server.", color=0xF2A2C0)
+                            coins_to_add = 100 + random.randint(0, 50)
+                            database.add_money(user_id, message.guild.id, coins_to_add, 0)
+                            embed = discord.Embed(description=f"<@{user_id}> received {coins_to_add} <a:pinkcoin:968277243946233906> for Bumping the server.", color=0xF2A2C0)
                             await message.channel.send(embed=embed)
                             return
                     except Exception:

--- a/Cogs/lock.py
+++ b/Cogs/lock.py
@@ -229,7 +229,8 @@ class Lock(commands.Cog):
             else:
                 await message.add_reaction(emoji='no:968277243266756618')
                 if random() < 0.1:
-                    database.remove_money(message.author.id, message.guild.id, 2, 0)
+                    coins_to_remove = (2 + random.randint(0, 3))
+                    database.remove_money(message.author.id, message.guild.id, coins_to_remove, 0)
 
     @commands.Cog.listener()
     async def on_guild_channel_delete(self, channel):

--- a/database.py
+++ b/database.py
@@ -1,4 +1,5 @@
 #!/bin/python3
+import random
 import psycopg2
 import pickle
 from os import environ
@@ -336,7 +337,8 @@ def lock(slave, guild, domme, num, sentence, roles):
 def update_lock(slave, sentence, guild):
     with con:
         cur.execute("UPDATE Prison SET num = num - 1, sentence = %s, count = count + 1 WHERE slaveid = %s AND guildid = %s", (sentence, slave, guild))
-    add_money(slave, guild, 15, 0)
+    coins_to_add = (30 + random.randint(0, 20))
+    add_money(slave, guild, coins_to_add, 0)
 
 
 def get_prisoner(slave, guild):


### PR DESCRIPTION
Made some changes to the coin reward amounts for chatting, lines (lock), and bumping the server. My thinking behind these increases is that on some servers, especially busier servers or servers with more bratty subs, it can be difficult for brat-tamer dommes/doms to maintain a balance of gems for gagging or lines.

Lines now give a base of 30 coins + up to 20 additional random coins. The thinking behind this increase is to make lines provide a bit of profit when given to unowned subs. With this change dommes/doms will have the ability to make subs farm them gems through lines as the subs will always get a base of 210 coins per 7 lines. I also increase the penalty amount for getting lines wrong, min 2 coins with up to 3 additional random coins are deducted when the wrong text penalty is applied. I decided to keep this smaller for the moment but I'm thinking this penalty could be even higher to help incentivize correctness.

The 10% chatting reward now gives 3 coins instead of 1. For regular chat activity, even on busier servers 1 coin felt too low, taking sometimes multiple weeks of regular activity to earn enough coins for a gem. Hopefully this gives the subs that don't participate in games a bit more income for getting dommes/doms gems.

Lastly the server bump reward was increased from 50 coins to 100 coins + an additional amount up to 50 coins. The thinking here is server bumping can only happen by a single member every few hours so this activity shouldn't be a significant source of coins for the economy at large, so why not sweeten the pot a bit